### PR TITLE
Update move_models.py (remove deprecated use of `ModelFilter`)

### DIFF
--- a/hf_operations/move_models.py
+++ b/hf_operations/move_models.py
@@ -1,11 +1,10 @@
 from pprint import pprint
 import os
-from huggingface_hub import ModelFilter, HfApi
+from huggingface_hub import HfApi
 
 api = HfApi()
-filt = ModelFilter(author='vocabtrimmer')
-models = api.list_models(filter=filt)
-models_filtered = [i.modelId for i in models if 'xlm-roberta-base' in i.modelId]
+models = api.list_models(author='vocabtrimmer')
+models_filtered = [i.id for i in models if 'xlm-roberta-base' in i.id]
 models_filtered = [i for i in models_filtered if "sentiment" in i and "trimmed" not in i]
 
 pprint(models_filtered)


### PR DESCRIPTION
This PR remove deprecated use of `ModelFilter`. Arguments can now be passed to `list_models` directly. See https://github.com/huggingface/huggingface_hub/issues/2028 for more details.